### PR TITLE
feat: add 云学堂

### DIFF
--- a/allow-list.sorl
+++ b/allow-list.sorl
@@ -932,6 +932,7 @@
 *.yunshipei.com
 *.yuque.com
 *.yuwantech.com
+*.yxt.com
 *.yy.com
 *.zaih.com
 *.zanata.org


### PR DESCRIPTION
http://yunxuetang.cn 旗下的域名，看起来是用作 CDN 的