### PR TITLE
feat: add pomotodo.com

### DIFF
--- a/allow-list.sorl
+++ b/allow-list.sorl
@@ -656,6 +656,7 @@
 *.pingwest.com
 *.planetmeican.com
 *.polyfill.io
+*.pomotodo.com
 *.ppgame.com
 *.pplink.link
 *.ppsimg.com


### PR DESCRIPTION
番茄工作法的 todolist

鉴于 todoist 国内有点难访问就转用这个了

还有一个竞品叫「专注清单」，之前叫「小番茄」，不过这个是 cn 域名的，就没必要加进去了。

推荐给你使用一下。