### PR TITLE
Remove *.linkedin.com

### DIFF
--- a/allow-list.sorl
+++ b/allow-list.sorl
@@ -626,7 +626,6 @@
 *.lifan.ooo
 *.likefont.com
 *.lilithgames.com
-*.linkedin.com
 *.linuxidc.com
 *.livechina.com
 *.liyin.date


### PR DESCRIPTION
“领英职场”于2023 年8 月9 日起正式停止服务